### PR TITLE
Rename org-mind-map-delete-space to org-mind-map-dot-node-name

### DIFF
--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -124,11 +124,9 @@
      s2
      "<br></br>")))
 
-(defun org-mind-map-delete-space (s)
+(defun org-mind-map-dot-node-name (s)
   "Make string S formatted to be usable within dot node names."
-  (replace-regexp-in-string "[^A-z0-9 ]" ""
-                            (replace-regexp-in-string "[ \\{}|\n]" "" s nil t)
-  nil t))
+  (replace-regexp-in-string "[^A-z0-9]" "" s nil t))
 
 (defun org-mind-map-add-color (h tag)
   "Add the color text H after tag TAG."
@@ -224,7 +222,7 @@
    splines=true;
    node [shape=plaintext];\n"
    (mapconcat 'identity (mapcar #'(lambda (x)
-                                    (concat (org-mind-map-delete-space x)
+                                    (concat (org-mind-map-dot-node-name x)
                                             " [label=<"
                                             x
                                             ">];\n"))
@@ -235,8 +233,8 @@
     'identity
     (mapcar #'(lambda (x)
                 (format "%s -> %s;\n"
-                        (org-mind-map-delete-space (first x))
-                        (org-mind-map-delete-space (second x))))
+                        (org-mind-map-dot-node-name (first x))
+                        (org-mind-map-dot-node-name (second x))))
             table)
     " ")
    (org-mind-map-make-legend legend)


### PR DESCRIPTION
This name better expresses what it does, which certainly is more than just delete spaces! I also took the liberty of simplifying the implementation a little.