### PR TITLE
Fix ampersand escaping for titles

### DIFF
--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -136,7 +136,7 @@
 (defun org-mind-map-write-tags (h el)
   "Use H as the hash-map of colors and takes an element EL and extracts the title and tags.  Then, formats the titles and tags so as to be usable within DOT's graphviz language."
   (let* ((wrapped-title (org-mind-map-wrap-lines (org-element-property :title el)))
-         (title (replace-regexp-in-string "&" "&amp;" title nil t))
+         (title (replace-regexp-in-string "&" "&amp;" wrapped-title nil t))
          (color (org-element-property :OMM-COLOR el))
 	(tags (org-element-property :tags el)))
     (concat "<table>"


### PR DESCRIPTION
Oops, I broke something with my previous patch, but this fixes it again. Many apologies.