### PR TITLE
fix : Symbols's function definition is void: first

### DIFF
--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -280,8 +280,8 @@ TAGS consistent."
     'identity
     (mapcar #'(lambda (x)
                 (format "%s -> %s;\n"
-                        (org-mind-map-dot-node-name (first x))
-                        (org-mind-map-dot-node-name (second x))))
+                        (org-mind-map-dot-node-name (nth 0 x))
+                        (org-mind-map-dot-node-name (nth 1 x))))
             table)
     " ")
    (org-mind-map-make-legend legend)


### PR DESCRIPTION
This fix fixes issue number 13 and number 8. The new emacs25 probably does not support first and second syntax anymore. The effect is that the plugin won't generate any pdf and shows the following error "Symbols's function definition is void: first".

Is working and tested on ubuntu 16.