### PR TITLE
make it more customizable

### DIFF
--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -29,6 +29,55 @@
 ;; tree as a directed graph.  Mail to <theodore.wiles@gmail.com> to discuss
 ;; features and additions.  All suggestions are more than welcome.
 
+;;; Commands:
+;;
+;; Below is a complete list of commands:
+;;
+;;  `org-mind-map-write'
+;;    Create a digraph based on all org trees in the current buffer.
+;;    Keybinding: M-x org-mind-map-write
+;;  `org-mind-map-write-current-branch'
+;;    Create a directed graph output based on just the current org tree branch.
+;;    Keybinding: M-x org-mind-map-write-current-branch
+;;  `org-mind-map-write-current-tree'
+;;    Create a directed graph output based on the whole current org tree.
+;;    Keybinding: M-x org-mind-map-write-current-tree
+;;
+;;; Customizable Options:
+;;
+;; Below is a list of customizable options:
+;;
+;;  `org-mind-map-wrap-line-length'
+;;    Line length within graphviz nodes.
+;;    default = 30
+;;  `org-mind-map-wrap-legend-line-length'
+;;    Line length of the graphviz legend.
+;;    default = 45
+;;  `org-mind-map-unflatten-command'
+;;    Shell executable command for running the UNFLATTEN command.
+;;    default = "unflatten -l3"
+;;  `org-mind-map-dot-command'
+;;    Shell executable command for running the DOT command.
+;;    default = "dot"
+;;  `org-mind-map-dot-output'
+;;    Format of the DOT output.  Defaults to PDF.
+;;    default = "pdf"
+;;  `org-mind-map-rankdir'
+;;    Sets the order of the resulting graph.
+;;    default = "LR"
+;;  `org-mind-map-engine'
+;;    Sets the layout engine used in your graphs.
+;;    default = "dot"
+;;  `org-mind-map-node-formats'
+;;    Assoc list of (NAME . FN) pairs where NAME is a value for the :OMM-NODE-FMT property 
+;;    default = nil
+;;  `org-mind-map-edge-formats'
+;;    Assoc list of (NAME . FN) pairs where NAME is a value for the :OMM-EDGE-FMT property
+;;    default = nil
+;;  `org-mind-map-edge-format-default'
+;;    Default format string for graph edges, e.g. "[style=dotted]".
+;;    default = ""
+
 ;; The headings of the org-mode file are treated as node text in the resulting tree.
 ;; Org-mode heading tags are included in the resulting tree as additional cells
 ;; within the node.
@@ -44,11 +93,14 @@
 ;; To install, add this code to your .emacs:
 ;; (load "org-mind-map.el")
 
-;; If on linux, customize the values of org-mind-map-unflatten-command
-;; and org-mind-map-dot-command to have the values corresponding to
+;; If on linux, customize the values of `org-mind-map-unflatten-command'
+;; and `org-mind-map-dot-command' to have the values corresponding to
 ;; the executables in your system.
 
-;; Then, run "M-x org-mind-map-write"
+;; Then, run "M-x org-mind-map-write" to create a graph of all trees in the current buffer,
+
+;; You can customize the style of the graph by adding :OMM-NODE-FMT and :OMM-EDGE-FMT properties
+;; to the headlines in the tree.
 
 ;; The latest version is available at:
 ;;
@@ -379,7 +431,7 @@ If LINKSP is non-nil include graph edges for org links."
 
 ;;;###autoload
 (defun org-mind-map-write-with-prompt nil
-  "Prompt for an output FILENAME (without extension) to write your .pdf and .dot files."
+  "Prompt for an output FILENAME (without extension) to write your output and .dot files."
   (let ((filename (read-file-name "What is the file name you would like to save to?")))
     (org-mind-map-write-named filename (concat filename ".dot")
 			      (y-or-n-p "Include org links? "))))

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -129,6 +129,19 @@ See the graphviz user manual for description of these options."
   (let* ((color (gethash tag h)))
     (concat "<td bgcolor=\"" color "\">" tag "</td>")))
 
+;; (defun org-mind-map-tags-default (title tags props color h)
+;;   ""
+;;   (concat "[label=<<table>"
+;; 	  (if (> (length tags) 0)
+;; 	      (concat "<tr><td colspan=\"" (int-to-string (length tags)) "\" ")
+;; 	    "<tr><td")
+;; 	  (if color (concat " bgcolor=\"" color "\" "))
+;; 	  ">" title "</td></tr>"
+;; 	  (if (> (length tags) 0)
+;; 	      (concat
+;; 	       "<tr>" (mapconcat (-partial 'org-mind-map-add-color h) tags "") "</tr>"))
+;; 	  "</table>>];\n"))
+
 ;; TODO: make this more flexible. Check for :OMM-NOTE-FMT property and add node properties.
 (defun org-mind-map-write-tags (h el)
   "Use H as the hash-map of colors and takes an element EL and extracts the title and tags.  
@@ -139,6 +152,7 @@ Then, formats the titles and tags so as to be usable within DOT's graphviz langu
          (color (org-element-property :OMM-COLOR el))
 	 (tags (org-element-property :tags el)))
     ;; Factor out following code as a separate function that is called if there are no node properties?
+    ;;(funcall fn title tags color)
     (concat "[label=<<table>"
 	    (if (> (length tags) 0)
 		(concat "<tr><td colspan=\"" (int-to-string (length tags)) "\" ")
@@ -182,15 +196,12 @@ Then, formats the titles and tags so as to be usable within DOT's graphviz langu
   "Make a list of links with the headline they are within and
 their destination. Pass TAGS in order to keep the hash-map of
 TAGS consistent."
-  (let* ((hm tags)
-         (output
-	  (org-element-map (org-element-parse-buffer 'object)
-	      'link
-	    (lambda (l)
-              (if (org-mind-map-valid-link? l)
-                  (list (org-mind-map-write-tags hm (org-mind-map-first-headline l))
-                        (org-mind-map-write-tags hm (org-mind-map-destination-headline l))))))))
-    output))
+  (org-element-map (org-element-parse-buffer 'object)
+      'link
+    (lambda (l)
+      (if (org-mind-map-valid-link? l)
+	  (list (org-mind-map-write-tags tags (org-mind-map-first-headline l))
+		(org-mind-map-write-tags tags (org-mind-map-destination-headline l)))))))
 
 
 (defun org-mind-map-make-legend (h)

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -331,42 +331,42 @@ and print the dotfile to the *Messages* buffer or to a file if DEBUG is a filena
       (set-process-sentinel p 'org-mind-map-update-message))))
 
 ;;;###autoload
-(defun org-mind-map-write-with-prompt (filename)
+(defun org-mind-map-write-with-prompt nil
   "Prompt for an output FILENAME (without extension) to write your .pdf and .dot files."
-  (interactive (list (read-file-name
-		      "What is the file name you would like to save to?")))
-  (org-mind-map-write-named filename (concat filename ".dot")))
+  (let ((filename (read-file-name "What is the file name you would like to save to?")))
+    (org-mind-map-write-named filename (concat filename ".dot"))))
 
 ;;;###autoload
-(defun org-mind-map-write (debugp)
+(defun org-mind-map-write (&optional promptp)
   "Create a digraph based on the org tree in the current buffer.
 The digraph will be named the same name as the current buffer.
 To customize, see the org-mind-map group.
-If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
+If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
   (interactive "P")
-  (org-mind-map-write-named (buffer-file-name) debugp))
+  (if promptp (org-mind-map-write-with-prompt)
+    (org-mind-map-write-named (buffer-file-name))))
 
 ;;;###autoload
-(defun org-mind-map-write-tree (debugp)
+(defun org-mind-map-write-tree (&optional promptp)
   "Create a directed graph output based on just the current org tree.
 To customize, see the org-mind-map group.
-If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
+If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
   (interactive "P")
   (org-narrow-to-subtree)
-  (let* ((title (nth 4 (org-heading-components))))
-    (org-mind-map-write-named (concat (buffer-file-name) title) debugp))
+  (if promptp (org-mind-map-write-with-prompt)
+    (org-mind-map-write-named (concat (buffer-file-name (nth 4 (org-heading-components))))))
   (widen))
 
-(defun org-mind-map-write-current-tree (debugp)
+(defun org-mind-map-write-current-tree (&optional promptp)
   "Create a directed graph output based on just the current org tree.
-If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
+If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
   (interactive "P")
   (save-restriction
     (if (> (funcall outline-level) 1)
 	(outline-up-heading 100))
     (org-narrow-to-subtree)
-    (let* ((title (nth 4 (org-heading-components))))
-      (org-mind-map-write-named "current" debugp))
+    (if promptp (org-mind-map-write-with-prompt)
+      (org-mind-map-write-named (concat (buffer-file-name (nth 4 (org-heading-components))))))
     (widen)))
 
 ;; Add a tool bar icon

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -388,7 +388,7 @@ If TREENAMEP is non-nil include in the filename the name of the top level header
 
 ;;;###autoload
 (defun org-mind-map-write (&optional promptp)
-  "Create a digraph based on the org tree in the current buffer.
+  "Create a digraph based on all org trees in the current buffer.
 The digraph will be named the same name as the current buffer.
 To customize, see the org-mind-map group.
 If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
@@ -397,8 +397,8 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
     (org-mind-map-write-named (org-mind-map-default-filename nil))))
 
 ;;;###autoload
-(defun org-mind-map-write-tree (&optional promptp)
-  "Create a directed graph output based on just the current org tree.
+(defun org-mind-map-write-current-branch (&optional promptp)
+  "Create a directed graph output based on just the current org tree branch.
 To customize, see the org-mind-map group.
 If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
   (interactive "P")
@@ -409,7 +409,7 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
 
 ;;;###autoload
 (defun org-mind-map-write-current-tree (&optional promptp)
-  "Create a directed graph output based on just the current org tree.
+  "Create a directed graph output based on the whole current org tree.
 If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
   (interactive "P")
   (save-restriction
@@ -436,7 +436,7 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
   '("Diagram of current tree" . org-mind-map-write-current-tree))
 
 (define-key org-mode-map [menu-bar Org Diagram branch]
-  '("Diagram of current branch" . org-mind-map-write-tree))
+  '("Diagram of current branch" . org-mind-map-write-current-branch))
 
 ;; (global-set-key (kbd "<f4>") 'org-mind-map-write)
 

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -326,13 +326,12 @@ If DEBUGP is non-nil, then print command and dotfile to *Messages* buffer."
     (set-process-sentinel p 'org-mind-map-update-message)))
 
 ;;;###autoload
-(defun org-mind-map-write-with-prompt (&optional debugp)
-  "Prompt for an output file name to write your org mode file.
+(defun org-mind-map-write-with-prompt (filename &optional debugp)
+  "Prompt for an output FILENAME to write your pdf file.
 If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
-  (interactive "P")
-  (org-mind-map-write-named
-   (read-file-name "What is the file name you would like to save to?")
-   debugp))
+  (interactive (list (read-file-name "What is the file name you would like to save to?")
+		     current-prefix-arg))
+  (org-mind-map-write-named filename debugp))
 
 ;;;###autoload
 (defun org-mind-map-write (debugp)

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -252,7 +252,8 @@ TAGS consistent."
     h))
 
 (defun org-mind-map-data (&optional linksp)
-  "Create graph & tag legend of all directed pairs of headlines for constructing the digraph."
+  "Create graph & tag legend of all directed pairs of headlines for constructing the digraph.
+If LINKSP is non-nil include graph edges for org links."
   (let* ((hm (org-mind-map-tags))
 	 (output
 	  (org-element-map (org-element-parse-buffer 'headline)
@@ -313,7 +314,8 @@ The output file will be in the same location as the org file, with the same name
   "Create a directed graph output based on the org tree in the current buffer, with name NAME.  
 To customize, see the org-mind-map group.
 If DEBUG is non-nil, then print the dot command to the *Messages* buffer,
-and print the dotfile to the *Messages* buffer or to a file if DEBUG is a filename."
+and print the dotfile to the *Messages* buffer or to a file if DEBUG is a filename.
+If LINKSP is non-nil include graph edges for org links."
   (let ((dot (org-mind-map-make-dot (org-mind-map-data linksp))))
     (if debug
 	(progn (message (org-mind-map-command name))

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -113,26 +113,33 @@ See the graphviz user manual for description of these options."
   :group 'org-mind-map)
 
 (defcustom org-mind-map-node-formats nil
-  "Assoc list of (NAME . FN) pairs where FN is a function which outputs a format string 
-to be placed after the node name (e.g. [label=\"Node1\",color=\"red\"]).
+  "Assoc list of (NAME . FN) pairs where NAME is a value for the :OMM-NODE-FMT property 
+of a node/headline, and FN is a function which outputs a format string to be placed after the 
+node name (e.g. [label=\"Node1\",color=\"red\"]).
 The function FN should take the following 5 arguments which can be used to construct the format: 
 
 TITLE = the label string for the node
 TAGS = a list of org tags for the current node
 COLOR = the contents of the OMM-COLOR property for the current node
 H = a hash map of colors
-EL = an org element obtained from `org-element-map'"
+EL = an org element obtained from `org-element-map'
+
+Note: the :OMM-NODE-FMT property is inherited by children of the node/headline where it is defined."
   :type '(alist :key-type (string :tag "Name")
 		:value-type (function :tag "Format function"))
   :group 'org-mind-map)
 
 (defcustom org-mind-map-edge-formats nil
-  "Assoc list of (NAME . FN) pairs where FN is a function which outputs a format string 
-to be placed after an edge (e.g. [style=dotted]).
+  "Assoc list of (NAME . FN) pairs where NAME is a value for the :OMM-EDGE-FMT property
+of a node/headline, and FN is a function which outputs a format string to be placed after an 
+edge (e.g. [style=dotted]). 
 The function FN should take the following 2 arguments which can be used to construct the format: 
 
 H = a hash map of colors
-EL = an org element obtained from `org-element-map'"
+EL = an org element obtained from `org-element-map'
+
+Note: the :OMM-EDGE-FMT property affects edges leading to the node at which it is defined, and 
+is inherited by children of that node/headline."
   :type '(alist :key-type (string :tag "Name")
 		:value-type (function :tag "Format function"))
   :group 'org-mind-map)

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -179,7 +179,7 @@ Then, formats the titles and tags so as to be usable within DOT's graphviz langu
       (let* ((org-link-search-inhibit-query t)
              (l (org-element-property :path e)))
         (save-excursion
-          (org-link-search l)
+	  (org-link-search l)
           t))
     ('error nil)))
 
@@ -362,8 +362,7 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
 If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
   (interactive "P")
   (save-restriction
-    (if (> (funcall outline-level) 1)
-	(outline-up-heading 100))
+    (ignore-errors (outline-up-heading 100))
     (org-narrow-to-subtree)
     (if promptp (org-mind-map-write-with-prompt)
       (org-mind-map-write-named (concat (buffer-file-name (nth 4 (org-heading-components))))))

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -251,7 +251,7 @@ TAGS consistent."
     (-map (lambda (x) (puthash x (org-mind-map-rgb) h)) unique-tags)
     h))
 
-(defun org-mind-map-data ()
+(defun org-mind-map-data (&optional linksp)
   "Create graph & tag legend of all directed pairs of headlines for constructing the digraph."
   (let* ((hm (org-mind-map-tags))
 	 (output
@@ -264,7 +264,7 @@ TAGS consistent."
 			   (org-mind-map-write-tags hm hl)
 			   ;; TODO: collect edge properties
 			   )))))))
-    (list (append output (org-mind-map-get-links hm)) hm)))
+    (list (append output (if linksp (org-mind-map-get-links hm))) hm)))
 
 (defun org-mind-map-make-dot (data)
   "Create the dot file from DATA."
@@ -309,12 +309,12 @@ The output file will be in the same location as the org file, with the same name
         (princ (format "Org mind map %s" event))
       (princ (format "Org mind map %sErrors: %s" event e)))))
 
-(defun org-mind-map-write-named (name &optional debug)
+(defun org-mind-map-write-named (name &optional debug linksp)
   "Create a directed graph output based on the org tree in the current buffer, with name NAME.  
 To customize, see the org-mind-map group.
 If DEBUG is non-nil, then print the dot command to the *Messages* buffer,
 and print the dotfile to the *Messages* buffer or to a file if DEBUG is a filename."
-  (let ((dot (org-mind-map-make-dot (org-mind-map-data))))
+  (let ((dot (org-mind-map-make-dot (org-mind-map-data linksp))))
     (if debug
 	(progn (message (org-mind-map-command name))
 	       (if (stringp debug)
@@ -334,7 +334,8 @@ and print the dotfile to the *Messages* buffer or to a file if DEBUG is a filena
 (defun org-mind-map-write-with-prompt nil
   "Prompt for an output FILENAME (without extension) to write your .pdf and .dot files."
   (let ((filename (read-file-name "What is the file name you would like to save to?")))
-    (org-mind-map-write-named filename (concat filename ".dot"))))
+    (org-mind-map-write-named filename (concat filename ".dot")
+			      (y-or-n-p "Include org links? "))))
 
 ;;;###autoload
 (defun org-mind-map-write (&optional promptp)

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -148,16 +148,16 @@ Then, formats the titles and tags so as to be usable within DOT's graphviz langu
                  "<tr>" (mapconcat (-partial 'org-mind-map-add-color h) tags "") "</tr>"))
 	    "</table>")))
 
-(defun first-headline (e)
+(defun org-mind-map-first-headline (e)
   "Figure out the first headline within element E."
   (let* ((parent (org-element-property :parent e)))
     (if parent
         (if (eq (org-element-type parent) 'headline)
             parent
-          (first-headline parent))
+          (org-mind-map-first-headline parent))
       nil)))
 
-(defun valid-link? (e)
+(defun org-mind-map-valid-link? (e)
   "Is E at a valid link?"
   (condition-case ex
       (let* ((org-link-search-inhibit-query t)
@@ -168,7 +168,7 @@ Then, formats the titles and tags so as to be usable within DOT's graphviz langu
     ('error nil)))
 
 
-(defun destination-headline (e)
+(defun org-mind-map-destination-headline (e)
   "Figure out where the link in E is pointing to."
   (let* ((l (org-element-property :path e))
          (org-link-search-inhibit-query t))
@@ -185,9 +185,9 @@ TAGS consistent."
 	  (org-element-map (org-element-parse-buffer 'object)
 	      'link
 	    (lambda (l)
-              (if (valid-link? l)
-                  (list (org-mind-map-write-tags hm (first-headline l))
-                        (org-mind-map-write-tags hm (destination-headline l))))))))
+              (if (org-mind-map-valid-link? l)
+                  (list (org-mind-map-write-tags hm (org-mind-map-first-headline l))
+                        (org-mind-map-write-tags hm (org-mind-map-destination-headline l))))))))
     output))
 
 

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -362,7 +362,8 @@ If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to
 If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
   (interactive "P")
   (save-restriction
-    (outline-up-heading 100)
+    (if (> (funcall outline-level) 1)
+	(outline-up-heading 100))
     (org-narrow-to-subtree)
     (let* ((title (nth 4 (org-heading-components))))
       (org-mind-map-write-named "current" debugp))

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -94,13 +94,15 @@
   :group 'org-mind-map)
 
 (defcustom org-mind-map-rankdir "LR"
-  "Sets the order of the resulting graph.  LR is left-to-right, and TB is top-to-bottom."
+  "Sets the order of the resulting graph.  
+LR is left-to-right, and TB is top-to-bottom."
   :type '(choice
           (const :tag "Left to right" "LR")
           (const :tag "Top to bottom" "TB")))
 
 (defcustom org-mind-map-engine "dot"
-  "Sets the layout engine used in your graphs.  See the graphviz user manual for description of these options."
+  "Sets the layout engine used in your graphs.  
+See the graphviz user manual for description of these options."
   :type '(choice
           (const :tag "Directed Graph" "dot")
           (const :tag "Undirected Spring Graph" "neato")
@@ -111,18 +113,12 @@
 (defun org-mind-map-wrap-lines (s)
   "Wraps a string S so that it can never be more than ORG-MIND-MAP-WRAP-LINE-LENGTH characters long."
   (let* ((s2 (org-do-wrap (split-string s " ") org-mind-map-wrap-line-length)))
-    (mapconcat
-     'identity
-     s2
-     "<br></br>")))
+    (mapconcat 'identity s2 "<br></br>")))
 
 (defun org-mind-map-wrap-legend-lines (s)
   "Wraps a string S so that it can never be more than ORG-MIND-MAP-WRAP-LEGEND-LINE-LENGTH characters long."
   (let* ((s2 (org-do-wrap (split-string s " ") org-mind-map-wrap-legend-line-length)))
-    (mapconcat
-     'identity
-     s2
-     "<br></br>")))
+    (mapconcat 'identity s2 "<br></br>")))
 
 (defun org-mind-map-dot-node-name (s)
   "Make string S formatted to be usable within dot node names."
@@ -134,12 +130,13 @@
     (concat "<td bgcolor=\"" color "\">" tag "</td>")))
 
 (defun org-mind-map-write-tags (h el)
-  "Use H as the hash-map of colors and takes an element EL and extracts the title and tags.  Then, formats the titles and tags so as to be usable within DOT's graphviz language."
+  "Use H as the hash-map of colors and takes an element EL and extracts the title and tags.  
+Then, formats the titles and tags so as to be usable within DOT's graphviz language."
   (let* ((ts (org-element-property :title el))
 	 (wrapped-title (org-mind-map-wrap-lines (if (listp ts) (first ts) ts)))
          (title (replace-regexp-in-string "&" "&amp;" wrapped-title nil t))
          (color (org-element-property :OMM-COLOR el))
-	(tags (org-element-property :tags el)))
+	 (tags (org-element-property :tags el)))
     (concat "<table>"
 	    (if (> (length tags) 0)
 		(concat "<tr><td colspan=\"" (int-to-string (length tags)) "\" ")
@@ -164,8 +161,7 @@
   "Is E at a valid link?"
   (condition-case ex
       (let* ((org-link-search-inhibit-query t)
-             (l (org-element-property :path e))
-             )
+             (l (org-element-property :path e)))
         (save-excursion
           (org-link-search l)
           t))
@@ -176,9 +172,9 @@
   "Figure out where the link in E is pointing to."
   (let* ((l (org-element-property :path e))
          (org-link-search-inhibit-query t))
-       (save-excursion
-         (org-open-link-from-string (concat "[[" l "]]"))
-         (org-element-at-point))))
+    (save-excursion
+      (org-open-link-from-string (concat "[[" l "]]"))
+      (org-element-at-point))))
 
 (defun org-mind-map-get-links (tags)
   "Make a list of links with the headline they are within and
@@ -222,9 +218,9 @@ TAGS consistent."
 (defun org-mind-map-rgb ()
   "Make a random pastel-like RGB color."
   (concat "#"
-   (format "%x" (+ 125 (random (- 255 125))))
-   (format "%x" (+ 125 (random (- 255 125))))
-   (format "%x" (+ 125 (random (- 255 125))))))
+	  (format "%x" (+ 125 (random (- 255 125))))
+	  (format "%x" (+ 125 (random (- 255 125))))
+	  (format "%x" (+ 125 (random (- 255 125))))))
 
 (defun org-mind-map-tags ()
   "Return a hash map of tags in the org file mapped to random colors."
@@ -232,9 +228,7 @@ TAGS consistent."
 	  (-distinct
 	   (-flatten
 	    (org-element-map (org-element-parse-buffer 'headline) 'headline
-	      (lambda (hl)
-		(let ((ts (org-element-property :tags hl)))
-		  ts))))))
+	      (lambda (hl) (org-element-property :tags hl))))))
 	 (h (make-hash-table :test 'equal)))
     (org-element-map (org-element-parse-buffer 'headline) 'headline
       (lambda (hl)
@@ -245,7 +239,7 @@ TAGS consistent."
     h))
 
 (defun org-mind-map-data ()
-  "Create a graph (output) and tag legend (hm) of all of the directed pairs of headlines to be used in constructing the directed graph."
+  "Create graph & tag legend of all directed pairs of headlines for constructing the digraph."
   (let* ((hm (org-mind-map-tags))
 	 (output
 	  (org-element-map (org-element-parse-buffer 'headline)
@@ -270,50 +264,45 @@ TAGS consistent."
    node [shape=plaintext];\n"
    (mapconcat 'identity (mapcar #'(lambda (x)
                                     (concat (org-mind-map-dot-node-name x)
-                                            " [label=<"
-                                            x
-                                            ">];\n"))
-                                (-distinct
-                                 (-flatten table)))
+                                            " [label=<" x ">];\n"))
+                                (-distinct (-flatten table)))
               " ")
-   (mapconcat
-    'identity
-    (mapcar #'(lambda (x)
-                (format "%s -> %s;\n"
-                        (org-mind-map-dot-node-name (nth 0 x))
-                        (org-mind-map-dot-node-name (nth 1 x))))
-            table)
-    " ")
+   (mapconcat 'identity (mapcar #'(lambda (x)
+				    (format "%s -> %s;\n"
+					    (org-mind-map-dot-node-name (nth 0 x))
+					    (org-mind-map-dot-node-name (nth 1 x))))
+				table)
+	      " ")
    (org-mind-map-make-legend legend)
    "}")))
 
 (defun org-mind-map-command (name)
-  "Return the shell script that will create the correct file.  The output file will be in the same location as the org file, with the same name as NAME."
+  "Return the shell script that will create the correct file.  
+The output file will be in the same location as the org file, with the same name as NAME."
   (concat org-mind-map-unflatten-command " | "
 	  org-mind-map-dot-command " -T"
 	  (shell-quote-argument org-mind-map-dot-output) " -K"
           (shell-quote-argument org-mind-map-engine) " -o"
-          (shell-quote-argument (concat
-                                 name
-                                 "." org-mind-map-dot-output ""
-                                 ))))
+          (shell-quote-argument (concat name "." org-mind-map-dot-output ""))))
 
 (defun org-mind-map-update-message (process event)
   "Write an update message on the output of running org-mind-map based on PROCESS and EVENT."
   (let* ((e (with-current-buffer "*org-mind-map-errors*"
-              (buffer-string))))
+	      (buffer-string))))
     (if (string= e "")
-        (princ
-         (format "Org mind map %s" event))
-      (princ
-       (format "Org mind map %sErrors: %s" event e)))))
+        (princ (format "Org mind map %s" event))
+      (princ (format "Org mind map %sErrors: %s" event e)))))
 
 (defun org-mind-map-write-named (name)
-  "Create a directed graph output based on the org tree in the current buffer, with name NAME.  To customize, see the org-mind-map group."
+  "Create a directed graph output based on the org tree in the current buffer, with name NAME.  
+To customize, see the org-mind-map group."
   (message (org-mind-map-command name))
-  (message (org-mind-map-make-dot (org-mind-map-data)) "%s")  (if (get-buffer "*org-mind-map-errors*")
+  (message (org-mind-map-make-dot (org-mind-map-data)) "%s")
+  (if (get-buffer "*org-mind-map-errors*")
       (kill-buffer "*org-mind-map-errors*"))
-  (let* ((p (start-process-shell-command "org-mind-map-s" "*org-mind-map-errors*" (org-mind-map-command name))))
+  (let* ((p (start-process-shell-command
+	     "org-mind-map-s" "*org-mind-map-errors*"
+	     (org-mind-map-command name))))
     (process-send-string p (org-mind-map-make-dot (org-mind-map-data)))
     (process-send-string p "\n")
     (process-send-eof p)
@@ -323,33 +312,36 @@ TAGS consistent."
 (defun org-mind-map-write-with-prompt ()
   "Prompt for an output file name to write your org mode file."
   (interactive)
-  (org-mind-map-write-named (read-file-name "What is the file name you would like to save to?" )))
+  (org-mind-map-write-named
+   (read-file-name "What is the file name you would like to save to?" )))
 
 ;;;###autoload
 (defun org-mind-map-write ()
-  "Create a directed graph output based on the org tree in the current buffer, named the same name as the current buffer.  To customize, see the org-mind-map group."
+  "Create a digraph based on the org tree in the current buffer.
+The digraph will be named the same name as the current buffer.
+To customize, see the org-mind-map group."
   (interactive)
   (org-mind-map-write-named (buffer-file-name)))
 
 ;;;###autoload
 (defun org-mind-map-write-tree ()
-  "Create a directed graph output based on just the current org tree.  To customize, see the org-mind-map group."
+  "Create a directed graph output based on just the current org tree.
+To customize, see the org-mind-map group."
   (interactive)
   (org-narrow-to-subtree)
   (let* ((title (nth 4 (org-heading-components))))
     (org-mind-map-write-named (concat (buffer-file-name) title)))
   (widen))
 
-
 (defun org-mind-map-write-current-tree ()
   "Create a directed graph output based on just the current org tree."
   (interactive)
   (save-restriction
-   (outline-up-heading 100)
-   (org-narrow-to-subtree)
-   (let* ((title (nth 4 (org-heading-components))))
-     (org-mind-map-write-named "current"))
-   (widen)))
+    (outline-up-heading 100)
+    (org-narrow-to-subtree)
+    (let* ((title (nth 4 (org-heading-components))))
+      (org-mind-map-write-named "current"))
+    (widen)))
 
 ;; Add a tool bar icon
 ;; (define-key org-mode-map [tool-bar org-button]

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -354,7 +354,7 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
   (interactive "P")
   (org-narrow-to-subtree)
   (if promptp (org-mind-map-write-with-prompt)
-    (org-mind-map-write-named (concat (buffer-file-name (nth 4 (org-heading-components))))))
+    (org-mind-map-write-named (concat (buffer-file-name) (nth 4 (org-heading-components)))))
   (widen))
 
 (defun org-mind-map-write-current-tree (&optional promptp)
@@ -365,7 +365,7 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
     (ignore-errors (outline-up-heading 100))
     (org-narrow-to-subtree)
     (if promptp (org-mind-map-write-with-prompt)
-      (org-mind-map-write-named (concat (buffer-file-name (nth 4 (org-heading-components))))))
+      (org-mind-map-write-named (concat (buffer-file-name) (nth 4 (org-heading-components)))))
     (widen)))
 
 ;; Add a tool bar icon

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -257,7 +257,7 @@ TAGS consistent."
 	 (output
 	  (org-element-map (org-element-parse-buffer 'headline)
 	      'headline
-	    (lambda(hl)
+	    (lambda (hl)
 	      (let ((parent (org-element-property :parent hl )))
 		(and (eq (org-element-type parent) 'headline)
 		     (list (org-mind-map-write-tags hm parent)

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -377,6 +377,15 @@ If LINKSP is non-nil include graph edges for org links."
     (org-mind-map-write-named filename (concat filename ".dot")
 			      (y-or-n-p "Include org links? "))))
 
+(defun org-mind-map-default-filename (treenamep)
+  "Return a default filename for saving the tree diagram.
+If TREENAMEP is non-nil include in the filename the name of the top level header of the tree."
+  (concat (file-name-sans-extension (buffer-name))
+	  "_diagram"
+	  (if treenamep
+	      (concat "-"
+		      (replace-regexp-in-string " +" "_" (nth 4 (org-heading-components)))))))
+
 ;;;###autoload
 (defun org-mind-map-write (&optional promptp)
   "Create a digraph based on the org tree in the current buffer.
@@ -385,7 +394,7 @@ To customize, see the org-mind-map group.
 If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
   (interactive "P")
   (if promptp (org-mind-map-write-with-prompt)
-    (org-mind-map-write-named (buffer-file-name))))
+    (org-mind-map-write-named (org-mind-map-default-filename nil))))
 
 ;;;###autoload
 (defun org-mind-map-write-tree (&optional promptp)
@@ -395,9 +404,10 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
   (interactive "P")
   (org-narrow-to-subtree)
   (if promptp (org-mind-map-write-with-prompt)
-    (org-mind-map-write-named (concat (buffer-file-name) (nth 4 (org-heading-components)))))
+    (org-mind-map-write-named (org-mind-map-default-filename t)))
   (widen))
 
+;;;###autoload
 (defun org-mind-map-write-current-tree (&optional promptp)
   "Create a directed graph output based on just the current org tree.
 If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write-with-prompt'."
@@ -406,7 +416,7 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
     (ignore-errors (outline-up-heading 100))
     (org-narrow-to-subtree)
     (if promptp (org-mind-map-write-with-prompt)
-      (org-mind-map-write-named (concat (buffer-file-name) (nth 4 (org-heading-components)))))
+      (org-mind-map-write-named (org-mind-map-default-filename t)))
     (widen)))
 
 ;; Add a tool bar icon

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -425,6 +425,19 @@ If called with prefix arg (or PROMPTP is non-nil), then call `org-mind-map-write
 ;;    :image (image :type xpm :file "info.xpm")
 ;;    ))
 
+;; Add menu items
+(define-key org-mode-map [menu-bar Org Diagram]
+  (cons "Graphviz diagram" (make-sparse-keymap "Graphviz diagram")))
+
+(define-key org-mode-map [menu-bar Org Diagram all]
+  '("Diagram of whole buffer" . org-mind-map-write))
+
+(define-key org-mode-map [menu-bar Org Diagram current]
+  '("Diagram of current tree" . org-mind-map-write-current-tree))
+
+(define-key org-mode-map [menu-bar Org Diagram branch]
+  '("Diagram of current branch" . org-mind-map-write-tree))
+
 ;; (global-set-key (kbd "<f4>") 'org-mind-map-write)
 
 (provide 'org-mind-map)

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -309,11 +309,12 @@ The output file will be in the same location as the org file, with the same name
         (princ (format "Org mind map %s" event))
       (princ (format "Org mind map %sErrors: %s" event e)))))
 
-(defun org-mind-map-write-named (name)
+(defun org-mind-map-write-named (name &optional debugp)
   "Create a directed graph output based on the org tree in the current buffer, with name NAME.  
-To customize, see the org-mind-map group."
-  (message (org-mind-map-command name))
-  (message (org-mind-map-make-dot (org-mind-map-data)) "%s")
+To customize, see the org-mind-map group.
+If DEBUGP is non-nil, then print command and dotfile to *Messages* buffer."
+  (if debugp (progn (message (org-mind-map-command name))
+		    (message (org-mind-map-make-dot (org-mind-map-data)) "%s")))
   (if (get-buffer "*org-mind-map-errors*")
       (kill-buffer "*org-mind-map-errors*"))
   (let* ((p (start-process-shell-command
@@ -325,38 +326,43 @@ To customize, see the org-mind-map group."
     (set-process-sentinel p 'org-mind-map-update-message)))
 
 ;;;###autoload
-(defun org-mind-map-write-with-prompt ()
-  "Prompt for an output file name to write your org mode file."
-  (interactive)
+(defun org-mind-map-write-with-prompt (&optional debugp)
+  "Prompt for an output file name to write your org mode file.
+If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
+  (interactive "P")
   (org-mind-map-write-named
-   (read-file-name "What is the file name you would like to save to?" )))
+   (read-file-name "What is the file name you would like to save to?")
+   debugp))
 
 ;;;###autoload
-(defun org-mind-map-write ()
+(defun org-mind-map-write (debugp)
   "Create a digraph based on the org tree in the current buffer.
 The digraph will be named the same name as the current buffer.
-To customize, see the org-mind-map group."
-  (interactive)
-  (org-mind-map-write-named (buffer-file-name)))
+To customize, see the org-mind-map group.
+If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
+  (interactive "P")
+  (org-mind-map-write-named (buffer-file-name) debugp))
 
 ;;;###autoload
-(defun org-mind-map-write-tree ()
+(defun org-mind-map-write-tree (debugp)
   "Create a directed graph output based on just the current org tree.
-To customize, see the org-mind-map group."
-  (interactive)
+To customize, see the org-mind-map group.
+If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
+  (interactive "P")
   (org-narrow-to-subtree)
   (let* ((title (nth 4 (org-heading-components))))
-    (org-mind-map-write-named (concat (buffer-file-name) title)))
+    (org-mind-map-write-named (concat (buffer-file-name) title) debugp))
   (widen))
 
-(defun org-mind-map-write-current-tree ()
-  "Create a directed graph output based on just the current org tree."
-  (interactive)
+(defun org-mind-map-write-current-tree (debugp)
+  "Create a directed graph output based on just the current org tree.
+If called with prefix arg (or DEBUGP non-nil), then print command and dotfile to *Messages* buffer."
+  (interactive "P")
   (save-restriction
     (outline-up-heading 100)
     (org-narrow-to-subtree)
     (let* ((title (nth 4 (org-heading-components))))
-      (org-mind-map-write-named "current"))
+      (org-mind-map-write-named "current" debugp))
     (widen)))
 
 ;; Add a tool bar icon


### PR DESCRIPTION
I made several changes to tidy up the code and make it more customizable so that you can define how the nodes and edges are formatted for each tree. The point of using functions in `org-mind-map-node-formats' and `org-mind-map-edge-formats' is that you might want the format to depend on the properties of each node (e.g "DECISION" nodes marked differently from "CHANCE" nodes). 