### PR TITLE
Patch org-mind-map for org version 9.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install, add this code to your .emacs:
 (require 'ox)
 (require 'ox-org)
 (require 'org-macs)
-(setq load-path (cons "~/.emacs.dir/org-mind-map/" load-path))
+(setq load-path (cons "INSTALLPATH" load-path))
 (require 'org-mind-map)
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ This package also relies on the org-mode and dash libraries, available from melp
 To install, add this code to your .emacs:
 
 ```elisp
-(load "INSTALLPATH/org-mind-map.el")
+(require 'ox)
+(require 'ox-org)
+(require 'org-macs)
+(setq load-path (cons "~/.emacs.dir/org-mind-map/" load-path))
+(require 'org-mind-map)
 ```
 
 Then, run `M-x org-mind-map-write` within the org-mode file you would like to make a mind-map for. If all works as expected, a PDF file will be generated in the same directory as the org file.

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -275,12 +275,12 @@ defined in `org-mind-map-node-formats'."
 
 (defun org-mind-map-wrap-lines (s)
   "Wraps a string S so that it can never be more than ORG-MIND-MAP-WRAP-LINE-LENGTH characters long."
-  (let* ((s2 (org-do-wrap (split-string s " ") org-mind-map-wrap-line-length)))
+  (let* ((s2 (org--do-wrap (split-string s " ") org-mind-map-wrap-line-length)))
     (mapconcat 'identity s2 "<br></br>")))
 
 (defun org-mind-map-wrap-legend-lines (s)
   "Wraps a string S so that it can never be more than ORG-MIND-MAP-WRAP-LEGEND-LINE-LENGTH characters long."
-  (let* ((s2 (org-do-wrap (split-string s " ") org-mind-map-wrap-legend-line-length)))
+  (let* ((s2 (org--do-wrap (split-string s " ") org-mind-map-wrap-legend-line-length)))
     (mapconcat 'identity s2 "<br></br>")))
 
 (defun org-mind-map-dot-node-name (s)


### PR DESCRIPTION
Loading the org-mind-map.el file directly can fail for some
installations. It is safer to require the packages needed
explicitely, add the org-min-map file to the load path and
then load it via require.

Calling 'org-do-wrap' failed. This needed to be changed to
'org--do-wrap'.