### PR TITLE
Support non-English node name

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ http://pages.sachachua.com/evil-plans/
 Customize the `org-mind-map-engine` variable to specify additional layout options (e.g. radial layouts where root nodes are in the center of the graph), and customize `org-mind-map-rankdir` to specify if the chart is going up-and-down or left-to-right.
 
 ## Selective Export
-   Use the command `org-mind-map-write-tree` to just create a map from the current tree.
+   Use the command `org-mind-map-write-current-tree` to just create a map from the current tree.

--- a/org-mind-map.el
+++ b/org-mind-map.el
@@ -285,12 +285,11 @@ defined in `org-mind-map-node-formats'."
 
 (defun org-mind-map-dot-node-name (s)
   "Make string S formatted to be usable within dot node names."
-  (replace-regexp-in-string
-   "[^A-Za-z0-9]" ""
-   (replace-regexp-in-string
-    "</?\\(table\\|tr\\|td\\)[^<>]*>" ""
-    (replace-regexp-in-string "label=\\(\"[^\"]+\"\\|[^,]+\\).*" "\\1" s))
-   nil t))
+  (concat "\""
+          (replace-regexp-in-string
+           "</?\\(table\\|tr\\|td\\)[^<>]*>" ""
+           (replace-regexp-in-string "label=\\(\"[^\"]+\"\\|[^,]+\\).*" "\\1" s))
+          "\""))
 
 (defun org-mind-map-add-color (hm tag &optional colspan)
   "Create data element containing TAG with associated color found in hashmap HM."


### PR DESCRIPTION
Hi,

This PR adds support for non-English node name of graph, I've tested it with below org:
  
    * node names of non-English characters
    ** Text
    *** 你好世界
    *** Hello Word
    ** long node name
    *** The quick brown fox jumps over the lazy dog
    *** 中文翻譯為「敏捷的棕毛狐狸從懶狗身上躍過」是一個著名的英語全字母句，常被用於測試字體的顯示效果和鍵盤有沒有故障。
    ** Punctuations and digits
    *** ,./?\|[]{}`!@#$%^&*()_+=-
    *** ！@#￥※（）
    *** 0123456789
  
Which exports to:
![mind-map-utf8_diagram](https://user-images.githubusercontent.com/1397818/41497294-f926a672-7184-11e8-9e0b-80b90b23bbfc.png)


Both chinese-gbk and utf-8 coding system for the org file exports correctly on my Linux box,
but I think utf-8 is recommended.
